### PR TITLE
Advocate the use of global NDEBUG

### DIFF
--- a/.github/workflows/poet_workflow.yml
+++ b/.github/workflows/poet_workflow.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/src/main.c
+++ b/src/main.c
@@ -20,10 +20,7 @@
 
 #define DEBUG_PRINT_ENABLE 0
 
-#if 0
-// Uncomment to disable asserts
-#define NDEBUG
-#endif
+// To disable asserts, define NDEBUG using compilation flags.
 
 #if 0
 move(ROW_DEBUG_ZERO + g_row_debug_current, COL_DEBUG_ZERO);


### PR DESCRIPTION
Defining in main.c would only affect main.c.